### PR TITLE
added Nick's ELSE statement to fix PV control of nEnable

### DIFF
--- a/plc-mfx-motion/mfx_motion/POUs/PRG_SPEC.TcPOU
+++ b/plc-mfx-motion/mfx_motion/POUs/PRG_SPEC.TcPOU
@@ -198,40 +198,42 @@ END_IF
 
 IF bHoldingCurrentEnable THEN
       Main.M15.nEnableMode := ENUM_StageEnableMode.ALWAYS;
-
       Main.M16.nEnableMode := ENUM_StageEnableMode.ALWAYS;
-
       Main.M17.nEnableMode := ENUM_StageEnableMode.ALWAYS;
-
       Main.M18.nEnableMode := ENUM_StageEnableMode.ALWAYS;
-
       Main.M19.nEnableMode := ENUM_StageEnableMode.ALWAYS;
-
       Main.M20.nEnableMode := ENUM_StageEnableMode.ALWAYS;
-
       Main.M21.nEnableMode := ENUM_StageEnableMode.ALWAYS;
-
       Main.M22.nEnableMode := ENUM_StageEnableMode.ALWAYS;
-
       Main.M23.nEnableMode := ENUM_StageEnableMode.ALWAYS;
-
       Main.M24.nEnableMode := ENUM_StageEnableMode.ALWAYS;
-
       Main.M25.nEnableMode := ENUM_StageEnableMode.ALWAYS;
-
       Main.M26.nEnableMode := ENUM_StageEnableMode.ALWAYS;
-
       Main.M27.nEnableMode := ENUM_StageEnableMode.ALWAYS;
-
       Main.M28.nEnableMode := ENUM_StageEnableMode.ALWAYS;
-
       Main.M29.nEnableMode := ENUM_StageEnableMode.ALWAYS;
-
       Main.M30.nEnableMode := ENUM_StageEnableMode.ALWAYS;
-
       Main.M31.nEnableMode := ENUM_StageEnableMode.ALWAYS;
-
       Main.M32.nEnableMode := ENUM_StageEnableMode.ALWAYS;
+ELSE
+      Main.M15.nEnableMode := ENUM_StageEnableMode.DURING_MOTION;
+      Main.M16.nEnableMode := ENUM_StageEnableMode.DURING_MOTION;
+      Main.M17.nEnableMode := ENUM_StageEnableMode.DURING_MOTION;
+      Main.M18.nEnableMode := ENUM_StageEnableMode.DURING_MOTION;
+      Main.M19.nEnableMode := ENUM_StageEnableMode.DURING_MOTION;
+      Main.M20.nEnableMode := ENUM_StageEnableMode.DURING_MOTION;
+      Main.M21.nEnableMode := ENUM_StageEnableMode.DURING_MOTION;
+      Main.M22.nEnableMode := ENUM_StageEnableMode.DURING_MOTION;
+      Main.M23.nEnableMode := ENUM_StageEnableMode.DURING_MOTION;
+      Main.M24.nEnableMode := ENUM_StageEnableMode.DURING_MOTION;
+      Main.M25.nEnableMode := ENUM_StageEnableMode.DURING_MOTION;
+      Main.M26.nEnableMode := ENUM_StageEnableMode.DURING_MOTION;
+      Main.M27.nEnableMode := ENUM_StageEnableMode.DURING_MOTION;
+      Main.M28.nEnableMode := ENUM_StageEnableMode.DURING_MOTION;
+      Main.M29.nEnableMode := ENUM_StageEnableMode.DURING_MOTION;
+      Main.M30.nEnableMode := ENUM_StageEnableMode.DURING_MOTION;
+      Main.M31.nEnableMode := ENUM_StageEnableMode.DURING_MOTION;
+      Main.M32.nEnableMode := ENUM_StageEnableMode.DURING_MOTION;
 END_IF
 ]]></ST>
     </Implementation>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
I was unable to merge Nick's PR that contained this fix, so I added the fix to my fork of master
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This is to fix the new PV: HOLDCUREN, which needed an ELSE statement added to the POU file.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Screenshots (if appropriate):

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive comments
- [ ] Test suite passes locally
- [ ] Libraries are set to fixed versions and not ``Always Newest``
- [ ] Code committed with ``pre-commit`` (alternatively ``pre-commit run --all-files``)
